### PR TITLE
Add CLI purge command, disable watchtower, and added support for TVDB ID

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,6 @@
 SCAN_PATH=/mnt/plex
-VIDEO_FILENAME=video1.strm
+VIDEO_FILENAME=trailer.strm
 WORKERS=4 # How many workers to use for scanning
 VIDEO_START_TIME=10  # Start at 10 seconds to avoid ads
 TMDB_API_KEY=your_tmdb_api_key
+ALGOLIA_API_KEY=algolia_api_key

--- a/README.md
+++ b/README.md
@@ -21,12 +21,14 @@
 
 # Trailerfin
 
-Trailerfin is a tool for automatically retrieving and refreshing IMDb trailer links for your media library as the backdrop video.
-Instead of downloading the trailer locally, it will create a .strm file that Jellyfin can use to play the video.  
+Trailerfin is a tool for automatically retrieving and refreshing trailer links for your media library as the backdrop video.
+It supports multiple ID formats (IMDb, TMDB, TVDB) and converts them to IMDb IDs for fetching trailers from IMDb.
+Instead of downloading the trailer locally, it will create a .strm file that Jellyfin can use to play the video.
 It will check the expiration of the link and only update when the link has expired.
 
 ## Features
-- Scans directories for IMDb IDs and updates trailer links
+- Scans directories for multiple ID formats: IMDb ({imdb-ttXXXXX}), TMDB ({tmdb-XXXXX}), TVDB ({tvdb-XXXXX})
+- Automatically converts TMDB/TVDB IDs to IMDb IDs for trailer fetching
 - Fetches the latest trailer or video from IMDb
 - Prioritizes trailers over clips when both are available
 - Maintains an ignore list for movies without trailers
@@ -38,7 +40,9 @@ It will check the expiration of the link and only update when the link has expir
 ## Requirements
 - Python 3.11+
 - Docker (recommended)
-- IMDb IDs in your media folder structure
+- Media folder structure with ID tags: {imdb-ttXXXXX}, {tmdb-XXXXX}, or {tvdb-XXXXX}
+- TMDB API key (for TMDB ID conversion)
+- Algolia API key (for TVDB ID conversion)
 - Make sure Theme videos are enabled in Settings > Display > Libraies per device
     <picture>
       <source media="(prefers-color-scheme: dark)" srcset="assets/trailerfin.png">
@@ -61,12 +65,29 @@ SCAN_PATH=/path/to/your/media
 VIDEO_FILENAME=trailer.strm
 WORKERS=4
 VIDEO_START_TIME=10
+TMDB_API_KEY=your_tmdb_api_key_here
+ALGOLIA_API_KEY=algolia_api_key
 ```
 
-- `SCAN_PATH`: Directory to scan for IMDb IDs
+- `SCAN_PATH`: Directory to scan for media IDs
 - `VIDEO_FILENAME`: Name of the .strm file to update
 - `WORKERS`: Amount of workers to use
 - `VIDEO_START_TIME`: Start time in seconds for the video (default: 10)
+- `TMDB_API_KEY`: API key from TMDB (required for TMDB ID conversion)
+- `ALGOLIA_API_KEY`: API key from Algolia (required for TVDB ID conversion)
+
+#### Obtaining the Algolia API Key from TVDB
+To retrieve the Algolia API key required for TVDB ID conversion, follow these steps:
+
+1. Open your browser and navigate to this example URL: [https://thetvdb.com/search?query=345246&menu%5Btype%5D=series](https://thetvdb.com/search?query=345246&menu%5Btype%5D=series)
+2. Open the browser's developer tools (press F12 or right-click > Inspect).
+3. Go to the **Network** tab, then **Fetch/XHR**.
+4. Reload the page (F5).
+5. In the list of requests, look for the one named **queries?x-algolia-agent**.
+6. Click on it, then go to the **Payload** tab.
+7. In the request parameters, look for the **x-algolia-key** field; its value is the Algolia API key.
+
+Use this key for the `ALGOLIA_API_KEY` variable in your `.env` file.
 
 ### 3. Build and Run with Docker
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       - saltbox
     labels:
       com.github.saltbox.saltbox_managed: true
+      com.centurylinklabs.watchtower.enable: false
     volumes:
       - /mnt:/mnt
       - /opt/trailerfin:/app


### PR DESCRIPTION
- Add the purge CLI command: New feature allowing trailer files to be purged via the command line interface, facilitating resource management.
- Added support for TVDB ID
- Watchtower deactivation: Configuration change to deactivate the watchtower service, potentially reducing system overhead.